### PR TITLE
Name qcheck tests.

### DIFF
--- a/2048/tests/test_g2048.ml
+++ b/2048/tests/test_g2048.ml
@@ -5,10 +5,10 @@ open Board_utils
 let mk_board_test = QCheck.mk_test ~n:1000 ~pp:string_of_board
 
 let check_board_property name ?size (prop : board -> bool) =
-  assert QCheck.(run (mk_board_test (arbitrary_board ?size) prop))
+  assert QCheck.(run (mk_board_test ~name (arbitrary_board ?size) prop))
 
 let check_full_board_property name ?size (prop : board -> bool) =
-  assert QCheck.(run (mk_board_test (arbitrary_full_board ?size) prop))
+  assert QCheck.(run (mk_board_test ~name (arbitrary_full_board ?size) prop))
 
 let test_shift_board_fixpoint () =
   check_board_property "Shifting reaches a fixpoint after width(board) shifts"


### PR DESCRIPTION
Pass test names through to make the output more informative.  Before:

```
testing property <anon prop>...
  [✔] passed 1000 tests (0 preconditions failed)
.testing property <anon prop>...
  [✔] passed 1000 tests (258 preconditions failed)
.testing property <anon prop>...
  [✔] passed 1000 tests (258 preconditions failed)
[etc.]
```

After:

```
testing property Shifting reaches a fixpoint after width(board) shifts...
  [✔] passed 1000 tests (0 preconditions failed)
.testing property Squares can be added to a board with spaces...
  [✔] passed 1000 tests (258 preconditions failed)
.testing property Squares can be randomly added to a board with spaces...
  [✔] passed 1000 tests (258 preconditions failed)
[etc.]
```
