### PR TITLE
Order and improve tests

### DIFF
--- a/2048/tests/board_utils.ml
+++ b/2048/tests/board_utils.ml
@@ -76,9 +76,3 @@ let is_row_full r = not (List.exists ((=)empty) r)
 
 let is_board_full b = List.for_all is_row_full b
 
-let test ?stage msg test =
-  let open OUnit in
-  match stage with
-  | None -> msg >:: test
-  | Some s when s <= current_stage -> msg >:: test
-  | _ -> msg >:: fun () -> todo msg; assert false

--- a/2048/tests/test_g2048.ml
+++ b/2048/tests/test_g2048.ml
@@ -399,58 +399,59 @@ let test_game_over () =
   end
 
 let suite = "2048 tests" >:::
+  let open Tests_enabled in 
   [
    (* 1. tests for is_board_winning *)
-   test ~stage:1 "test is_board_winning"
+   test ~stage:Winning_board "test is_board_winning"
     test_is_board_winning;
 
    (* 2. tests for shifts *)
-   test ~stage:2 "test shifting empty rows"
+   test ~stage:Shifting "test shifting empty rows"
     test_shift_empty;
 
-   test ~stage:2 "test shifting moves empty squares to the right"
+   test ~stage:Shifting "test shifting moves empty squares to the right"
     test_shift_empty_squares;
 
-   test ~stage:2 "test shifting can coalesce equal squares"
+   test ~stage:Shifting "test shifting can coalesce equal squares"
     test_shift_coalesce;
 
-   test ~stage:2 "test shifts"
+   test ~stage:Shifting "test shifts"
     test_shifts;
 
-   test ~stage:2 "a fixpoint is reached after width(board) shift_boards"
+   test ~stage:Shifting "a fixpoint is reached after width(board) shift_boards"
     test_shift_board_fixpoint;
 
    (* 3. tests for insertions *)
-   test ~stage:3 "insertion into completely empty rows"
+   test ~stage:Inserting "insertion into completely empty rows"
     test_insert_row_completely_empty;
 
-   test ~stage:3 "insertion into partially empty rows"
+   test ~stage:Inserting "insertion into partially empty rows"
     test_insert_row_partially_empty;
 
-   test ~stage:3 "insertion into full rows"
+   test ~stage:Inserting "insertion into full rows"
     test_insert_row_full;
 
-   test ~stage:3 "insertion into last empty square"
+   test ~stage:Inserting "insertion into last empty square"
     test_insert_last_square;
 
-   test ~stage:3 "squares can be added to a board that is not fully-populated"
+   test ~stage:Inserting "squares can be added to a board that is not fully-populated"
     test_add;
 
-   test ~stage:3 "squares cannot be added to a fully-populated board"
+   test ~stage:Inserting "squares cannot be added to a fully-populated board"
     test_add_to_full;
 
-   test ~stage:3 "test insert_square"
+   test ~stage:Inserting "test insert_square"
     test_insert;
 
    (* 4. tests for is_game_over *)
-   test ~stage:4 "test game over"
+   test ~stage:Game_over "test game over"
     test_game_over;
 
    (* 5. tests for provenance *) 
-   test ~stage:5 "test row provenance"
+   test ~stage:Provenance "test row provenance"
     test_row_provenance;
 
-   test ~stage:5 "test provenance"
+   test ~stage:Provenance "test provenance"
     test_provenance;
 
    (* Always-on tests *)

--- a/2048/tests/tests_enabled.ml
+++ b/2048/tests/tests_enabled.ml
@@ -1,0 +1,21 @@
+type stages =
+    Winning_board
+  | Shifting
+  | Inserting
+  | Game_over
+  | Provenance
+
+let tests_enabled = [
+  Winning_board;
+  Shifting;
+  Inserting;
+  Game_over;
+  Provenance;
+]
+
+let test ?stage msg test =
+  let open OUnit in
+  match stage with
+  | None -> msg >:: test
+  | Some s when List.mem s tests_enabled -> msg >:: test
+  | _ -> msg >:: fun () -> todo msg; assert false


### PR DESCRIPTION
Turn the tests into more of a guide through the steps.  There are now six tutorial steps, four "core" and two "extended", and the tests can be progressively enabled to follow the implementation order.
### Core steps
1. Logic for whether a board is a winning board:
   - write `is_square_2048`
   - write `is_board_winning` using `is_square_2048`
2. Logic for shifting the board left, right, up and down.
   - write `shift_left_helper`
   - write `shift_board` using `shift_left_helper`
3. Logic for inserting new squares
   - write `insert_into_row` using `replace_one` from `Utils`
   - write `insert_square` using `replace_one` and `insert_into_row`

(At this point the game should be somewhat playable.)
1. Logic for whether a board is a losing board
   - write `is_complete_row`
   - write `is_game_over` using `is_complete_row`
### Extension steps
1. Provenance of tiles.  This enables sliding animations.
   - write `square_provenances`
   - update the `shift`s / `string_of_square` / etc. functions
2. Making new square insertion non-deterministic
   - Update `insert_square` to use a random position, using `Utils.replace_at`
